### PR TITLE
PAF-29 Fix change_variables

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -5,6 +5,7 @@ verify_ssl = true
 
 [dev-packages]
 pylint = "*"
+autopep8 = "*"
 
 [packages]
 requests = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "77a8ff979e86db2dbee37d61df51e4c07c6ff62a9fb8a71b6bb5dde83b2d1575"
+            "sha256": "661f0c6028f892faee91814dacb44c678abaf7b6d1645af87357c1483119fa7f"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -61,6 +61,13 @@
             ],
             "version": "==2.4.2"
         },
+        "autopep8": {
+            "hashes": [
+                "sha256:60fd8c4341bab59963dafd5d2a566e94f547e660b9b396f772afe67d8481dbf0"
+            ],
+            "index": "pypi",
+            "version": "==1.5.3"
+        },
         "isort": {
             "hashes": [
                 "sha256:54da7e92468955c4fceacd0c86bd0ec997b0e1ee80d97f67c35a78b719dccab1",
@@ -100,6 +107,13 @@
                 "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"
             ],
             "version": "==0.6.1"
+        },
+        "pycodestyle": {
+            "hashes": [
+                "sha256:2295e7b2f6b5bd100585ebcb1f616591b652db8a741695b3d8f5d28bdc934367",
+                "sha256:c58a7d2815e0e8d7972bf1803331fb0152f867bd89adf8a01dfd55085434192e"
+            ],
+            "version": "==2.6.0"
         },
         "pylint": {
             "hashes": [

--- a/change_variables.py
+++ b/change_variables.py
@@ -1,15 +1,25 @@
 """Replace active variables with another set"""
-import sys
+from platform import system
+import argparse
 import os
 
-def replace_env():
+def replace_set(set_file):
   """Replace Variable File"""
-  print("Enter Set to Import: ", end='')
-  new_env = input()
-
-  if "windows" in sys.platform:
-    os.system("copy variable_sets\\" + str(new_env) + ".py user_variables.py")
+  # Options are Darwin, Linux, Java and Windows. Java not supported
+  if "Windows" in system():
+    os.system("copy variable_sets\\" + str(set_file) + ".py user_variables.py")
   else:
-    os.system("cp variable_sets/" + str(new_env) + ".py user_variables.py")
+    os.system("cp variable_sets/" + str(set_file) + ".py user_variables.py")
 
-replace_env()
+def get_variable_set_file(variable_set_arg):
+  """Checks if the set file was provided via arg else prompt"""
+  if variable_set_arg:
+    return variable_set_arg
+  return input("Enter Set to Import: ")
+
+if __name__ == '__main__':
+  parser = argparse.ArgumentParser()
+  parser.add_argument('--set-file', '-s')
+  args = parser.parse_args()
+  set_file = get_variable_set_file(args.set_file)
+  replace_set(set_file)


### PR DESCRIPTION
Broken Things Fixed:

Mac OS support
Allowing for variable set to be passed via argument ("s" or "-set-file").

Updating pipfile to include autopep8
