### PR TITLE
Paf 35 radus version

### DIFF
--- a/dynatrace/requests/request_handler.py
+++ b/dynatrace/requests/request_handler.py
@@ -245,31 +245,25 @@ def v2_get_results_by_page(cluster, endpoint, item, tenant=None, params=None):
     Gets a multi-paged result set one page at a time. To be used with V2 API
     pagination where the nextPageKey is returned in the body of the response.
     \n
-    @param item - item being retrieved (e.g. entities, metrics, etc.)\n
     @param cluster - Cluster dictionary from variable_set\n
     @param endpoint - API endpoint to call.\n
     @param tenant - String of tenant name used in cluster dictionary\n
     @param params - dictionary of query string parameters
     """
-    # Make the first API call; retrieve summary info and first page of results
-    response = make_api_call(
-        cluster=cluster,
-        endpoint=endpoint,
-        tenant=tenant,
-        params=params
-    ).json()
-    cursor = response.get('nextPageKey')
-    # Pause here and return 1st page
-    yield response
-
-    # On subsequent calls, yield page by page the remaining result set
+    # We'll always make at least 1 call
+    cursor = 1
     while cursor:
+        # On subsequent calls, must omit all other params
+        if cursor != 1:
+            params = dict(nextPageKey=cursor)
+
         response = make_api_call(
             cluster=cluster,
             endpoint=endpoint,
             tenant=tenant,
-            params=dict(nextPageKey=cursor)
+            params=params
         ).json()
+
         yield response
         cursor = response.get('nextPageKey')
 

--- a/dynatrace/requests/request_handler.py
+++ b/dynatrace/requests/request_handler.py
@@ -176,7 +176,7 @@ def v2_get_results_whole(cluster, endpoint, item, tenant=None, params=None):
     # In the case of multi-page, get the rest
     cursor = response.get('nextPageKey')
     if cursor:
-        response[item].extend(__get_multipage_results(
+        response[item].extend(__get_v2_multipage_results(
             cluster=cluster,
             endpoint=endpoint,
             tenant=tenant,

--- a/dynatrace/requests/request_handler.py
+++ b/dynatrace/requests/request_handler.py
@@ -156,12 +156,13 @@ def v2_get_results_whole(cluster, endpoint, item, tenant=None, params=None):
     """
     Gets a multi-paged result set and returns it whole. To be used with V2 API
     pagination where the nextPageKey is returned in the body of the response.
+    Also this type of query requires the queried item so we can extract it from
+    the subsequent pages and omit the summary data.
     \n
     @param item - item being retrieved (e.g. entities, metrics, etc.)\n
     @param cluster - Cluster dictionary from variable_set\n
     @param endpoint - API endpoint to call.\n
     @param tenant - String of tenant name used in cluster dictionary\n
-    @param cursor - cursor that was returned with the first page of results\n
     @param params - dictionary of query string parameters
     """
     # Get the first results set (including cursor)
@@ -184,6 +185,59 @@ def v2_get_results_whole(cluster, endpoint, item, tenant=None, params=None):
         ))
 
     return response
+
+
+def v1_get_results_whole(cluster, endpoint, tenant=None, params=None):
+    """
+    Gets a multi-paged result set and returns it whole. To be used with V1 API
+    pagination where the next-page-key is returned in the response headers.
+    \n
+    @param cluster - Cluster dictionary from variable_set\n
+    @param endpoint - API endpoint to call.\n
+    @param tenant - String of tenant name used in cluster dictionary\n
+    @param params - dictionary of query string parameters
+    """
+    results = []
+    # We'll always make at least 1 call
+    cursor = 1
+    while cursor:
+        if cursor != 1:
+            params['nextPageKey'] = cursor
+        response = make_api_call(
+            cluster=cluster,
+            tenant=tenant,
+            endpoint=endpoint,
+            params=params
+        )
+        results.extend(response.json())
+        cursor = response.headers.get('next-page-key')
+
+    return results
+
+
+def v1_get_results_by_page(cluster, endpoint, tenant=None, params=None):
+    """
+    Gets a multi-paged result set one page at a time. To be used with V1 API
+    pagination where the next-page-key is returned in the response headers.
+    \n
+    @param cluster - Cluster dictionary from variable_set\n
+    @param endpoint - API endpoint to call.\n
+    @param tenant - String of tenant name used in cluster dictionary\n
+    @param params - dictionary of query string parameters
+    """
+    cursor = 1
+    while cursor:
+        if cursor != 1:
+            params['nextPageKey'] = cursor
+        response = make_api_call(
+            cluster=cluster,
+            tenant=tenant,
+            endpoint=endpoint,
+            params=params
+        )
+        # Pause here and return this page of results
+        yield response.json()
+        cursor = response.headers.get('next-page-key')
 
 
 def v2_get_results_by_page(cluster, endpoint, item, tenant=None, params=None):

--- a/dynatrace/requests/request_handler.py
+++ b/dynatrace/requests/request_handler.py
@@ -122,7 +122,7 @@ def make_api_call(cluster, endpoint, tenant=None, params=None, json=None, method
     return response
 
 
-def __get_multipage_results(cluster, endpoint, cursor, item, tenant=None):
+def __get_v2_multipage_results(cluster, endpoint, cursor, item, tenant=None):
     """
     Private function: not intended for calling from outside of this module.
     Retrieves subsequent pages of multi-page API call and gathers just the


### PR DESCRIPTION
Added a few functions in Request Handler for multi-paged results (on both V1 & V2) with whole sets or page-by-page options. Will allow handling large result sets better (e.g. events or entities).