### PR TITLE
PAF 49 - Update core topology functions to use API V2 instead of V1

### DIFF
--- a/dynatrace/tenant/host_groups.py
+++ b/dynatrace/tenant/host_groups.py
@@ -1,5 +1,5 @@
-"""Host Group Information for Tenant"""
-from dynatrace.tenant.topology import hosts as topology_hosts
+"""Module for host group type entity operations"""
+import dynatrace.tenant.topology.shared as entity_api
 
 # TODO redo export function (break out to export function?)
 # def export_host_groups_setwide(full_set):
@@ -21,49 +21,68 @@ def get_host_groups_tenantwide(cluster, tenant):
     Returns:
         Dict: List of Host Groups in the tenant
     """
-    params = {
-        'relativeTime': 'day',
-        'includeDetails': 'true'
+    response = entity_api.get_entities(
+        cluster=cluster,
+        tenant=tenant,
+        entity_type=entity_api.EntityTypes.HOST_GROUP,
+        params={
+            'from': 'now-24h'
+        }
+    )
+    host_groups = {
+        hg.get('entityId'): hg.get('displayName')
+        for hg in response
     }
-    response = topology_hosts.get_hosts_tenantwide(cluster,
-                                                   tenant,
-                                                   params=params)
-    host_groups = {}
-    for host in response:
-        if host.get('hostGroup'):
-            host_groups[host['hostGroup']['meId']] = host['hostGroup']['name']
     return host_groups
 
 
-def get_host_groups_clusterwide(cluster):
+def get_host_groups_clusterwide(cluster, tenant_split=False):
     """Get all Host Groups used in the Cluster
 
     Args:
         cluster (cluster dict): Current cluster to operate on
+        tenant_split (bool): whether to split results by tenant or not
 
     Returns:
-        dict: Dictionary of all Host Groups used in the Cluster
+        dict: Dictionary of all Host Groups used in the Cluster.
+              If split by tenant, keys are tenants, values are dicts of
+              tenant's host groups.
     """
-    # TODO add split_by_tenant optional variable
-    host_groups_custerwide = {}
-    for tenant in cluster['tenant']:
-        host_groups_custerwide.update(
-            get_host_groups_tenantwide(cluster, tenant)
-        )
-    return host_groups_custerwide
+    host_groups = {}
+
+    if tenant_split:
+        for tenant in cluster['tenant']:
+            host_groups[tenant] = get_host_groups_tenantwide(cluster, tenant)
+    else:
+        for tenant in cluster['tenant']:
+            host_groups.update(
+                get_host_groups_tenantwide(cluster, tenant)
+            )
+
+    return host_groups
 
 
-def get_host_groups_setwide(full_set):
-    # TODO add split_by_tenant optional variable
+def get_host_groups_setwide(full_set, tenant_split=False):
     """Get all Host Groups used in the Cluster Set
 
     Args:
         full_set (dict of cluster dict): Current cluster to operate on
+        tenant_split (bool): whether to split results by tenant or not
 
     Returns:
         dict: Dictionary of all Host Groups used in the Cluster Set
+              If split by tenant, keys are tenants, values are dicts of
+              tenant's host groups.
     """
-    host_groups_setwide = {}
-    for cluster in full_set.values():
-        host_groups_setwide.update(get_host_groups_clusterwide(cluster))
-    return host_groups_setwide
+    host_groups = {}
+
+    if tenant_split:
+        for cluster in full_set.values():
+            host_groups.update(get_host_groups_clusterwide(
+                cluster=cluster,
+                tenant_split=True))
+    else:
+        for cluster in full_set.values():
+            host_groups.update(get_host_groups_clusterwide(cluster))
+
+    return host_groups

--- a/dynatrace/tenant/topology/applications.py
+++ b/dynatrace/tenant/topology/applications.py
@@ -1,19 +1,19 @@
-import dynatrace.tenant.topology.shared as entity
+import dynatrace.tenant.topology.shared as entity_api
 import dynatrace.requests.request_handler as rh
 
 
 def get_applications_tenantwide(cluster, tenant):
     """Get Information for all applications in a tenant"""
-    return entity.get_entities(
+    return entity_api.get_entities(
         cluster=cluster,
         tenant=tenant,
-        entity_type=entity.EntityTypes.APPLICATION
+        entity_type=entity_api.EntityTypes.APPLICATION
     )
 
 
 def get_application(cluster, tenant, entity):
     """Get Information for one application in a tenant"""
-    return entity.get_entity(
+    return entity_api.get_entity(
         cluster=cluster,
         tenant=tenant,
         entity_id=entity
@@ -42,27 +42,27 @@ def get_application_count_tenantwide(cluster, tenant):
         "from": "now-24h"
     }
 
-    return entity.get_env_entity_count(
+    return entity_api.get_env_entity_count(
         cluster=cluster,
         tenant=tenant,
-        entity_type=entity.EntityTypes.APPLICATION,
+        entity_type=entity_api.EntityTypes.APPLICATION,
         params=params
     )
 
 
 def get_application_count_clusterwide(cluster):
     """Get total count for all applications in cluster"""
-    return entity.get_cluster_entity_count(
+    return entity_api.get_cluster_entity_count(
         cluster=cluster,
-        entity_type=entity.EntityTypes.APPLICATION
+        entity_type=entity_api.EntityTypes.APPLICATION
     )
 
 
 def get_application_count_setwide(full_set):
     """Get total count of applications in cluster set"""
-    return entity.get_set_entity_count(
+    return entity_api.get_set_entity_count(
         full_set=full_set,
-        entity_type=entity.EntityTypes.APPLICATION
+        entity_type=entity_api.EntityTypes.APPLICATION
     )
 
 

--- a/dynatrace/tenant/topology/applications.py
+++ b/dynatrace/tenant/topology/applications.py
@@ -1,3 +1,5 @@
+"""Module for application type entity operations"""
+
 import dynatrace.tenant.topology.shared as entity_api
 import dynatrace.requests.request_handler as rh
 

--- a/dynatrace/tenant/topology/custom.py
+++ b/dynatrace/tenant/topology/custom.py
@@ -1,7 +1,15 @@
-"""Module for interacting with Custom Topology Actions"""
-import dynatrace.tenant.topology.shared as topology_shared
+import dynatrace.requests.request_handler as rh
 
 
 def set_custom_properties(cluster, tenant, entity, prop_json):
-    """Update properties of process_group entity"""
-    return topology_shared.set_env_layer_properties(cluster, tenant, 'custom', entity, prop_json)
+    """Creates or updates properties of custom device entity"""
+    if not prop_json.get('customDeviceId'):
+        prop_json['customDeviceId'] = entity
+        
+    return rh.make_api_call(
+        cluster=cluster,
+        tenant=tenant,
+        endpoint=f'{rh.TenantAPIs.ENTITIES}/custom',
+        method=rh.HTTP.POST,
+        json=prop_json
+    )

--- a/dynatrace/tenant/topology/custom.py
+++ b/dynatrace/tenant/topology/custom.py
@@ -1,3 +1,5 @@
+"""Module or custom device type entity operations"""
+
 import dynatrace.requests.request_handler as rh
 
 
@@ -5,7 +7,7 @@ def set_custom_properties(cluster, tenant, entity, prop_json):
     """Creates or updates properties of custom device entity"""
     if not prop_json.get('customDeviceId'):
         prop_json['customDeviceId'] = entity
-        
+
     return rh.make_api_call(
         cluster=cluster,
         tenant=tenant,

--- a/dynatrace/tenant/topology/hosts.py
+++ b/dynatrace/tenant/topology/hosts.py
@@ -1,3 +1,5 @@
+"""Module for host type entity operations"""
+
 import dynatrace.tenant.topology.shared as entity_api
 import dynatrace.requests.request_handler as rh
 

--- a/dynatrace/tenant/topology/hosts.py
+++ b/dynatrace/tenant/topology/hosts.py
@@ -1,52 +1,86 @@
-"""Host operations from the Dynatrace API"""
-import dynatrace.tenant.topology.shared as topology_shared
-from dynatrace.requests import request_handler as rh
+import dynatrace.tenant.topology.shared as entity_api
+import dynatrace.requests.request_handler as rh
 
 
 def get_hosts_tenantwide(cluster, tenant, params=None):
     """Get Information for all hosts in a tenant"""
-    return topology_shared.get_env_layer_entities(cluster, tenant, 'hosts', params=params)
+    return entity_api.get_entities(
+        cluster=cluster,
+        tenant=tenant,
+        entity_type=entity_api.EntityTypes.HOST
+    )
 
 
 def get_host(cluster, tenant, entity, params=None):
-    """Get Information on one host for in a tenant"""
-    return topology_shared.get_env_layer_entity(cluster, tenant, 'hosts', entity, params=params)
+    """Get Information for one host in a tenant"""
+    return entity_api.get_entity(
+        cluster=cluster,
+        tenant=tenant,
+        entity_id=entity
+    )
 
 
 def set_host_properties(cluster, tenant, entity, prop_json):
     """Update properties of host entity"""
-    return topology_shared.set_env_layer_properties(cluster, tenant, 'hosts', entity, prop_json)
+    response = rh.make_api_call(
+        cluster=cluster,
+        tenant=tenant,
+        endpoint=rh.TenantAPIs.TAGS,
+        params={
+            'entitySelector': f'entityId("{entity}")'
+        },
+        method=rh.HTTP.POST,
+        json=prop_json
+    )
+
+    return response.json()
 
 
 def get_host_count_tenantwide(cluster, tenant, params=None):
     """Get total count for all hosts in a tenant"""
-    return topology_shared.get_env_layer_count(cluster, tenant, 'hosts', params=params)
+    return entity_api.get_env_entity_count(
+        cluster=cluster,
+        tenant=tenant,
+        entity_type=entity_api.EntityTypes.HOST,
+        params=params
+    )
 
 
 def get_host_count_clusterwide(cluster, params=None):
     """Get total count for all hosts in cluster"""
-    return topology_shared.get_cluster_layer_count(cluster, 'hosts', params=params)
+    return entity_api.get_cluster_entity_count(
+        cluster=cluster,
+        entity_type=entity_api.EntityTypes.HOST,
+        params=params
+    )
 
 
 def get_host_count_setwide(full_set, params=None):
-    """Get total count of hosts for all clusters definied in variable file"""
-    return topology_shared.get_set_layer_count(full_set, 'hosts', params=params)
+    """Get total count of hosts in cluster set"""
+    return entity_api.get_set_entity_count(
+        full_set=full_set,
+        entity_type=entity_api.EntityTypes.HOST,
+        params=params
+    )
 
 
 def add_host_tags(cluster, tenant, entity, tag_list):
     """Add tags to host"""
-    return topology_shared.add_env_layer_tags(cluster, tenant, 'hosts', entity, tag_list)
+    return entity_api.add_tags(
+        cluster=cluster,
+        tenant=tenant,
+        tag_list=tag_list,
+        entity_id=entity
+    )
 
 
 def delete_host_tag(cluster, tenant, entity, tag):
     """Remove single tag from host"""
-    if tag is None:
-        raise TypeError("Tag cannot be None!")
-    return rh.make_api_call(
+    return entity_api.delete_tag(
         cluster=cluster,
         tenant=tenant,
-        method=rh.HTTP.DELETE,
-        endpoint=f"{rh.TenantAPIs.V1_TOPOLOGY}/infrastructure/hosts/{entity}/tags/{tag}"
+        tag_key=tag,
+        entity_id=entity
     )
 
 
@@ -62,9 +96,13 @@ def get_host_units_tenantwide(cluster, tenant, params=None):
         float: total consumed units used in tenant
     """
     consumed_host_units = 0
-    host_list = get_hosts_tenantwide(cluster, tenant, params=params)
+    host_list = rh.make_api_call(
+        cluster,
+        tenant,
+        endpoint=f'{rh.TenantAPIs.V1_TOPOLOGY}/infrastructure/hosts',
+        params=params)
     for host in host_list:
-        consumed_host_units = consumed_host_units + host['consumedHostUnits']
+        consumed_host_units += host['consumedHostUnits']
     return consumed_host_units
 
 

--- a/dynatrace/tenant/topology/hosts.py
+++ b/dynatrace/tenant/topology/hosts.py
@@ -101,10 +101,11 @@ def get_host_units_tenantwide(cluster, tenant, params=None):
     """
     consumed_host_units = 0
     host_list = rh.make_api_call(
-        cluster,
-        tenant,
+        cluster=cluster,
+        tenant=tenant,
         endpoint=f'{rh.TenantAPIs.V1_TOPOLOGY}/infrastructure/hosts',
-        params=params)
+        params=params
+    ).json()
     for host in host_list:
         consumed_host_units += host['consumedHostUnits']
     return consumed_host_units

--- a/dynatrace/tenant/topology/hosts.py
+++ b/dynatrace/tenant/topology/hosts.py
@@ -7,7 +7,8 @@ def get_hosts_tenantwide(cluster, tenant, params=None):
     return entity_api.get_entities(
         cluster=cluster,
         tenant=tenant,
-        entity_type=entity_api.EntityTypes.HOST
+        entity_type=entity_api.EntityTypes.HOST,
+        params=params
     )
 
 
@@ -16,7 +17,8 @@ def get_host(cluster, tenant, entity, params=None):
     return entity_api.get_entity(
         cluster=cluster,
         tenant=tenant,
-        entity_id=entity
+        entity_id=entity,
+        params=params
     )
 
 

--- a/dynatrace/tenant/topology/process.py
+++ b/dynatrace/tenant/topology/process.py
@@ -1,12 +1,21 @@
-"""Process operations from the Dynatrace API"""
-import dynatrace.tenant.topology.shared as topology_shared
+import dynatrace.tenant.topology.shared as entity_api
 
 
 def get_processes_tenantwide(cluster, tenant, params=None):
     """Get Information for all processes in a tenant"""
-    return topology_shared.get_env_layer_entities(cluster, tenant, 'processes', params=params)
+    return entity_api.get_entities(
+        cluster=cluster,
+        tenant=tenant,
+        entity_type=entity_api.EntityTypes.PROCESS_GROUP_INSTANCE,
+        params=params
+    )
 
 
 def get_process(cluster, tenant, entity, params=None):
     """Get Information on one process for in a tenant"""
-    return topology_shared.get_env_layer_entity(cluster, tenant, 'processes', entity, params=params)
+    return entity_api.get_entity(
+        cluster=cluster,
+        tenant=tenant,
+        entity_id=entity,
+        params=params
+    )

--- a/dynatrace/tenant/topology/process.py
+++ b/dynatrace/tenant/topology/process.py
@@ -1,3 +1,5 @@
+"""Module for process type entity operations"""
+
 import dynatrace.tenant.topology.shared as entity_api
 
 

--- a/dynatrace/tenant/topology/process_groups.py
+++ b/dynatrace/tenant/topology/process_groups.py
@@ -1,3 +1,5 @@
+"""Module for process group type entity operations"""
+
 import dynatrace.tenant.topology.shared as entity_api
 import dynatrace.requests.request_handler as rh
 

--- a/dynatrace/tenant/topology/process_groups.py
+++ b/dynatrace/tenant/topology/process_groups.py
@@ -3,7 +3,7 @@ import dynatrace.requests.request_handler as rh
 
 
 def get_process_groups_tenantwide(cluster, tenant):
-    """Get Information for all process_groups in a tenant"""
+    """Get Information for all process groups in a tenant"""
     return entity_api.get_entities(
         cluster=cluster,
         tenant=tenant,
@@ -12,7 +12,7 @@ def get_process_groups_tenantwide(cluster, tenant):
 
 
 def get_process_group(cluster, tenant, entity):
-    """Get Information for one process_group in a tenant"""
+    """Get Information for one process group in a tenant"""
     return entity_api.get_entity(
         cluster=cluster,
         tenant=tenant,
@@ -21,7 +21,7 @@ def get_process_group(cluster, tenant, entity):
 
 
 def set_process_group_properties(cluster, tenant, entity, prop_json):
-    """Update properties of process_group entity"""
+    """Update properties of process group entity"""
     response = rh.make_api_call(
         cluster=cluster,
         tenant=tenant,
@@ -37,7 +37,7 @@ def set_process_group_properties(cluster, tenant, entity, prop_json):
 
 
 def get_process_group_count_tenantwide(cluster, tenant, params=None):
-    """Get total count for all process_groups in a tenant"""
+    """Get total count for all process groups in a tenant"""
     return entity_api.get_env_entity_count(
         cluster=cluster,
         tenant=tenant,
@@ -47,7 +47,7 @@ def get_process_group_count_tenantwide(cluster, tenant, params=None):
 
 
 def get_process_group_count_clusterwide(cluster, params=None):
-    """Get total count for all process_groups in cluster"""
+    """Get total count for all process groups in cluster"""
     return entity_api.get_cluster_entity_count(
         cluster=cluster,
         entity_type=entity_api.EntityTypes.PROCESS_GROUP,
@@ -56,7 +56,7 @@ def get_process_group_count_clusterwide(cluster, params=None):
 
 
 def get_process_group_count_setwide(full_set, params=None):
-    """Get total count of process_groups in cluster set"""
+    """Get total count of process groups in cluster set"""
     return entity_api.get_set_entity_count(
         full_set=full_set,
         entity_type=entity_api.EntityTypes.PROCESS_GROUP,

--- a/dynatrace/tenant/topology/process_groups.py
+++ b/dynatrace/tenant/topology/process_groups.py
@@ -1,43 +1,74 @@
-"""Process Group operations from the Dynatrace API"""
-import dynatrace.tenant.topology.shared as topology_shared
+import dynatrace.tenant.topology.shared as entity_api
+import dynatrace.requests.request_handler as rh
 
 
 def get_process_groups_tenantwide(cluster, tenant):
-    """Get Information for all process-groups in a tenant"""
-    return topology_shared.get_env_layer_entities(cluster, tenant, 'process-groups')
-
-
-def get_process_group(cluster, tenant, entity):
-    """Get Information on one process-group for in a tenant"""
-    return topology_shared.get_env_layer_entity(cluster, tenant, 'process-groups', entity)
-
-
-def set_process_group_properties(cluster, tenant, entity, prop_json):
-    """Update properties of process-group entity"""
-    return topology_shared.set_env_layer_properties(
-        cluster,
-        tenant,
-        'process-groups',
-        entity,
-        prop_json
+    """Get Information for all process_groups in a tenant"""
+    return entity_api.get_entities(
+        cluster=cluster,
+        tenant=tenant,
+        entity_type=entity_api.EntityTypes.PROCESS_GROUP
     )
 
 
+def get_process_group(cluster, tenant, entity):
+    """Get Information for one process_group in a tenant"""
+    return entity_api.get_entity(
+        cluster=cluster,
+        tenant=tenant,
+        entity_id=entity
+    )
+
+
+def set_process_group_properties(cluster, tenant, entity, prop_json):
+    """Update properties of process_group entity"""
+    response = rh.make_api_call(
+        cluster=cluster,
+        tenant=tenant,
+        endpoint=rh.TenantAPIs.TAGS,
+        params={
+            'entitySelector': f'entityId("{entity}")'
+        },
+        method=rh.HTTP.POST,
+        json=prop_json
+    )
+
+    return response.json()
+
+
 def get_process_group_count_tenantwide(cluster, tenant, params=None):
-    """Get total count for all process-groups in a tenant"""
-    return topology_shared.get_env_layer_count(cluster, tenant, 'process-groups', params=params)
+    """Get total count for all process_groups in a tenant"""
+    return entity_api.get_env_entity_count(
+        cluster=cluster,
+        tenant=tenant,
+        entity_type=entity_api.EntityTypes.PROCESS_GROUP,
+        params=params
+    )
 
 
 def get_process_group_count_clusterwide(cluster, params=None):
-    """Get total count for all process-groups in cluster"""
-    return topology_shared.get_cluster_layer_count(cluster, 'process-groups', params=params)
+    """Get total count for all process_groups in cluster"""
+    return entity_api.get_cluster_entity_count(
+        cluster=cluster,
+        entity_type=entity_api.EntityTypes.PROCESS_GROUP,
+        params=params
+    )
 
 
 def get_process_group_count_setwide(full_set, params=None):
-    """Get total count of process-groups for all clusters defined in variable file"""
-    return topology_shared.get_set_layer_count(full_set, 'process-groups', params=params)
+    """Get total count of process_groups in cluster set"""
+    return entity_api.get_set_entity_count(
+        full_set=full_set,
+        entity_type=entity_api.EntityTypes.PROCESS_GROUP,
+        params=params
+    )
 
 
 def add_process_group_tags(cluster, tenant, entity, tag_list):
     """Add tags to a process group"""
-    return topology_shared.add_env_layer_tags(cluster, tenant, 'process-groups', entity, tag_list)
+    return entity_api.add_tags(
+        cluster=cluster,
+        tenant=tenant,
+        tag_list=tag_list,
+        entity_id=entity
+    )

--- a/dynatrace/tenant/topology/services.py
+++ b/dynatrace/tenant/topology/services.py
@@ -1,3 +1,5 @@
+"""Module for service type entity operations"""
+
 import dynatrace.tenant.topology.shared as entity_api
 import dynatrace.requests.request_handler as rh
 

--- a/dynatrace/tenant/topology/services.py
+++ b/dynatrace/tenant/topology/services.py
@@ -1,37 +1,74 @@
-"""Service operations from the Dynatrace API"""
-import dynatrace.tenant.topology.shared as topology_shared
+import dynatrace.tenant.topology.shared as entity_api
+import dynatrace.requests.request_handler as rh
 
 
 def get_services_tenantwide(cluster, tenant):
     """Get Information for all services in a tenant"""
-    return topology_shared.get_env_layer_entities(cluster, tenant, 'services')
+    return entity_api.get_entities(
+        cluster=cluster,
+        tenant=tenant,
+        entity_type=entity_api.EntityTypes.SERVICE
+    )
 
 
 def get_service(cluster, tenant, entity):
-    """Get Information on one service for in a tenant"""
-    return topology_shared.get_env_layer_entity(cluster, tenant, 'services', entity)
+    """Get Information for one service in a tenant"""
+    return entity_api.get_entity(
+        cluster=cluster,
+        tenant=tenant,
+        entity_id=entity
+    )
 
 
 def set_service_properties(cluster, tenant, entity, prop_json):
     """Update properties of service entity"""
-    return topology_shared.set_env_layer_properties(cluster, tenant, 'services', entity, prop_json)
+    response = rh.make_api_call(
+        cluster=cluster,
+        tenant=tenant,
+        endpoint=rh.TenantAPIs.TAGS,
+        params={
+            'entitySelector': f'entityId("{entity}")'
+        },
+        method=rh.HTTP.POST,
+        json=prop_json
+    )
+
+    return response.json()
 
 
 def get_service_count_tenantwide(cluster, tenant, params=None):
     """Get total count for all services in a tenant"""
-    return topology_shared.get_env_layer_count(cluster, tenant, 'services', params=params)
+    return entity_api.get_env_entity_count(
+        cluster=cluster,
+        tenant=tenant,
+        entity_type=entity_api.EntityTypes.SERVICE,
+        params=params
+    )
 
 
 def get_service_count_clusterwide(cluster, params=None):
     """Get total count for all services in cluster"""
-    return topology_shared.get_cluster_layer_count(cluster, 'services', params=params)
+    return entity_api.get_cluster_entity_count(
+        cluster=cluster,
+        entity_type=entity_api.EntityTypes.SERVICE,
+        params=params
+    )
 
 
 def get_service_count_setwide(full_set, params=None):
-    """Get total count of services for all clusters definied in variable file"""
-    return topology_shared.get_set_layer_count(full_set, 'services', params=params)
+    """Get total count of services in cluster set"""
+    return entity_api.get_set_entity_count(
+        full_set=full_set,
+        entity_type=entity_api.EntityTypes.SERVICE,
+        params=params
+    )
 
 
 def add_service_tags(cluster, tenant, entity, tag_list):
     """Add tags to a service"""
-    return topology_shared.add_env_layer_tags(cluster, tenant, 'services', entity, tag_list)
+    return entity_api.add_tags(
+        cluster=cluster,
+        tenant=tenant,
+        tag_list=tag_list,
+        entity_id=entity
+    )

--- a/dynatrace/tenant/topology/shared.py
+++ b/dynatrace/tenant/topology/shared.py
@@ -104,10 +104,10 @@ class EntityTypes(Enum):
     CUSTOM_DEVICE_GROUP = auto()
 
     def __str__(self):
-        return self.name
+        return str(self.name)
 
     def __repr__(self):
-        return self.name
+        return str(self.name)
 
 
 def get_entities(cluster, tenant, entity_type, params=None):
@@ -140,9 +140,9 @@ def get_entity(cluster, tenant, entity_id, params=None):
 
     # If params already contains entitySelector, don't overwrite
     if params.get('entitySelector'):
-        params['entitySelector'] += f'entityId("{entity_id}")'
+        params['entitySelector'] += f'entityId({entity_id})'
     else:
-        params['entitySelector'] = f'entityId("{entity_id}")'
+        params['entitySelector'] = f'entityId({entity_id})'
 
     response = rh.make_api_call(
         cluster=cluster,

--- a/dynatrace/tenant/topology/shared.py
+++ b/dynatrace/tenant/topology/shared.py
@@ -1,153 +1,309 @@
-"""Shared topology operations for multiple layers from the Dynatrace API"""
+from enum import Enum, auto
 from dynatrace.requests import request_handler as rh
-# Layer Compatibility
-# 1. Get all entities - application, host, process, process group, service
-#   1a. Count all entities
-# 2. Get specific entity - application, host process, process group, service
-# 3. Update properties of entity - application, custom, host, process group, service
-
-ENDPOINT_SUFFIX = {
-        'applications': 'applications',
-        'custom': "infrastructure/custom",
-        'hosts': "infrastructure/hosts",
-        'processes': "infrastructure/processes",
-        'process-groups': "infrastructure/process-groups",
-        'services': "infrastructure/services"
-}
 
 
-def check_valid_layer(layer, layer_list):
-    """Check if the operation is valid for the layer"""
-    if layer is None or layer_list is None:
-        raise TypeError('Provide layer and layer_list!')
-    if layer not in layer_list:
-        raise ValueError(
-            layer + " layer does not exist or is invalid for this use!")
+class EntityTypes(Enum):
+    """Accepted values for EntityType arguments"""
+    HTTP_CHECK = auto()
+    RELATIONAL_DATABASE_SERVICE = auto()
+    APPLICATION = auto()
+    KUBERNETES_NODE = auto()
+    CONTAINER_GROUP_INSTANCE = auto()
+    OPENSTACK_COMPUTE_NODE = auto()
+    QUEUE = auto()
+    EBS_VOLUME = auto()
+    OPENSTACK_PROJECT = auto()
+    PROCESS_GROUP = auto()
+    EC2_INSTANCE = auto()
+    GEOLOC_SITE = auto()
+    DEVICE_APPLICATION_METHOD_GROUP = auto()
+    AWS_AVAILABILITY_ZONE = auto()
+    SYNTHETIC_TEST_STEP = auto()
+    AZURE_STORAGE_ACCOUNT = auto()
+    AZURE_IOT_HUB = auto()
+    AWS_APPLICATION_LOAD_BALANCER = auto()
+    CLOUD_APPLICATION_NAMESPACE = auto()
+    BROWSER = auto()
+    GEOLOCATION = auto()
+    HTTP_CHECK_STEP = auto()
+    HYPERVISOR_DISK = auto()
+    AZURE_APP_SERVICE_PLAN = auto()
+    NEUTRON_SUBNET = auto()
+    S3BUCKET = auto()
+    NETWORK_INTERFACE = auto()
+    QUEUE_INSTANCE = auto()
+    APPLICATION_METHOD_GROUP = auto()
+    GCP_ZONE = auto()
+    OPENSTACK_VM = auto()
+    MOBILE_APPLICATION = auto()
+    PROCESS_GROUP_INSTANCE = auto()
+    HOST_GROUP = auto()
+    SYNTHETIC_LOCATION = auto()
+    SERVICE_INSTANCE = auto()
+    GOOGLE_COMPUTE_ENGINE = auto()
+    AZURE_SERVICE_BUS_TOPIC = auto()
+    AZURE_TENANT = auto()
+    CLOUD_APPLICATION = auto()
+    AZURE_EVENT_HUB = auto()
+    DEVICE_APPLICATION_METHOD = auto()
+    AZURE_SERVICE_BUS_NAMESPACE = auto()
+    VIRTUALMACHINE = auto()
+    ELASTIC_LOAD_BALANCER = auto()
+    AZURE_SUBSCRIPTION = auto()
+    AZURE_REDIS_CACHE = auto()
+    AWS_NETWORK_LOAD_BALANCER = auto()
+    BOSH_DEPLOYMENT = auto()
+    EXTERNAL_SYNTHETIC_TEST_STEP = auto()
+    DOCKER_CONTAINER_GROUP_INSTANCE = auto()
+    APPLICATION_METHOD = auto()
+    AZURE_CREDENTIALS = auto()
+    AZURE_MGMT_GROUP = auto()
+    SERVICE_METHOD_GROUP = auto()
+    AZURE_FUNCTION_APP = auto()
+    AZURE_SQL_SERVER = auto()
+    AZURE_SQL_DATABASE = auto()
+    AZURE_VM = auto()
+    OPENSTACK_AVAILABILITY_ZONE = auto()
+    SWIFT_CONTAINER = auto()
+    CLOUD_APPLICATION_INSTANCE = auto()
+    SERVICE = auto()
+    VMWARE_DATACENTER = auto()
+    AZURE_EVENT_HUB_NAMESPACE = auto()
+    VCENTER = auto()
+    AZURE_SERVICE_BUS_QUEUE = auto()
+    SERVICE_METHOD = auto()
+    OS = auto()
+    CONTAINER_GROUP = auto()
+    AWS_CREDENTIALS = auto()
+    AZURE_SQL_ELASTIC_POOL = auto()
+    DATASTORE = auto()
+    HYPERVISOR_CLUSTER = auto()
+    SYNTHETIC_TEST = auto()
+    EXTERNAL_SYNTHETIC_TEST = auto()
+    AUTO_SCALING_GROUP = auto()
+    CUSTOM_APPLICATION = auto()
+    AZURE_API_MANAGEMENT_SERVICE = auto()
+    DISK = auto()
+    HYPERVISOR = auto()
+    CUSTOM_DEVICE = auto()
+    AZURE_REGION = auto()
+    CINDER_VOLUME = auto()
+    DOCKER_CONTAINER_GROUP = auto()
+    KUBERNETES_CLUSTER = auto()
+    AZURE_WEB_APP = auto()
+    HOST = auto()
+    AZURE_LOAD_BALANCER = auto()
+    OPENSTACK_REGION = auto()
+    AWS_LAMBDA_FUNCTION = auto()
+    AZURE_APPLICATION_GATEWAY = auto()
+    AZURE_VM_SCALE_SET = auto()
+    AZURE_COSMOS_DB = auto()
+    DYNAMO_DB_TABLE = auto()
+    CUSTOM_DEVICE_GROUP = auto()
+
+    def __str__(self):
+        return self.name
+
+    def __repr__(self):
+        return self.name
 
 
-def get_env_layer_entities(cluster, tenant, layer, params=None):
-    """Get all Entities of Specified Layer"""
-    layer_list = ['applications', 'hosts',
-                  'processes', 'process-groups', 'services']
-    check_valid_layer(layer, layer_list)
-
+def get_entities(cluster, tenant, entity_type, params=None):
+    """Get all Entities of specified type. Use EntityTypes enum."""
     if not params:
         params = {}
+
+    # If params already contains entitySelector, don't overwrite
+    if params.get('entitySelector'):
+        params['entitySelector'] += f'type("{entity_type}")'
+    else:
+        params['entitySelector'] = f'type("{entity_type}")'
 
     response = rh.make_api_call(
         cluster=cluster,
         tenant=tenant,
-        endpoint=f"{rh.TenantAPIs.V1_TOPOLOGY}/{ENDPOINT_SUFFIX[layer]}",
+        endpoint=rh.TenantAPIs.ENTITIES,
         params=params
     )
     return response.json()
 
 
-def get_env_layer_entity(cluster, tenant, layer, entity, params=None):
-    """Get Entity Information for Specified Layer"""
-    layer_list = ['applications', 'hosts',
-                  'processes', 'process-groups', 'services']
-    check_valid_layer(layer, layer_list)
-
+def get_entity(cluster, tenant, entity_id, params=None):
+    """
+    Get the details of an entity specified by ID.
+    You can use more than one ID if it's quoted and comma separated ("id-1","id-2")
+    """
     if not params:
         params = {}
+
+    # If params already contains entitySelector, don't overwrite
+    if params.get('entitySelector'):
+        params['entitySelector'] += f'entityId("{entity_id}")'
+    else:
+        params['entitySelector'] = f'entityId("{entity_id}")'
 
     response = rh.make_api_call(
         cluster=cluster,
         tenant=tenant,
-        endpoint=f"{rh.TenantAPIs.V1_TOPOLOGY}/{ENDPOINT_SUFFIX[layer]}/{entity}",
+        endpoint=rh.TenantAPIs.ENTITIES,
         params=params
     )
     return response.json()
 
 
-def set_env_layer_properties(cluster, tenant, layer, entity, prop_json):
-    """Update Properties of Entity"""
-    layer_list = ['applications', 'custom',
-                  'hosts', 'process-groups', 'services']
-    check_valid_layer(layer, layer_list)
-    response = rh.make_api_call(
-        cluster=cluster,
-        tenant=tenant,
-        method=rh.HTTP.POST,
-        endpoint=f"{rh.TenantAPIs.V1_TOPOLOGY}/{ENDPOINT_SUFFIX[layer]}/{entity}",
-        json=prop_json
-    )
-    return response.status_code
-
-
-def get_env_layer_count(cluster, tenant, layer, params=None):
-    """Get total hosts in an environment"""
+def get_env_entity_count(cluster, tenant, entity_type, params=None):
+    """
+    Get total number of entities of a given type in an environment.
+    Use EntityType enum.
+    """
     if not params:
         params = {}
 
-    layer_list = ['applications', 'hosts',
-                  'processes', 'process-groups', 'services']
+    if 'from' not in params:
+        params['from'] = "now-24h"
 
-    if 'relativeTime' not in params.keys():
-        params['relativeTime'] = "day"
-    if 'includeDetails' not in params.keys():
-        params['includeDetails'] = False
+    # If params already contains entitySelector, don't overwrite
+    if params.get('entitySelector'):
+        params['entitySelector'] += f'type("{entity_type}")'
+    else:
+        params['entitySelector'] = f'type("{entity_type}")'
 
-    check_valid_layer(layer, layer_list)
     response = rh.make_api_call(cluster=cluster,
                                 tenant=tenant,
-                                endpoint=f"{rh.TenantAPIs.V1_TOPOLOGY}/{ENDPOINT_SUFFIX[layer]}",
+                                endpoint=rh.TenantAPIs.ENTITIES,
                                 params=params)
     env_layer_count = len(response.json())
     return env_layer_count
 
 
-def get_cluster_layer_count(cluster, layer, params=None):
-    """Get total count for all environments in cluster"""
-
+def get_cluster_entity_count(cluster, entity_type, params=None):
+    """
+    Get total number of entitites of a given type for all environments
+    in cluster. Use EntityType enum.
+    """
     if not params:
         params = {}
 
-    cluster_layer_count = 0
-    for env_key in cluster['tenant']:
-        cluster_layer_count += get_env_layer_count(cluster=cluster,
-                                                   tenant=env_key,
-                                                   layer=layer,
-                                                   params=params)
-    return cluster_layer_count
+    count = 0
+    for tenant in cluster['tenant']:
+        count += get_env_entity_count(
+            cluster=cluster,
+            tenant=tenant,
+            entity_type=entity_type,
+            params=params
+        )
+    return count
 
 
-def get_set_layer_count(full_set, layer, params=None):
+def get_set_entity_count(full_set, entity_type, params=None):
     """Get total count for all clusters definied in variable file"""
     if not params:
         params = {}
 
-    full_set_layer_count = 0
+    count = 0
     for cluster in full_set.values():
-        full_set_layer_count += get_cluster_layer_count(cluster,
-                                                        layer,
-                                                        params)
-    return full_set_layer_count
+        count += get_cluster_entity_count(
+            cluster=cluster,
+            entity_type=entity_type,
+            params=params
+        )
+    return count
 
 
-def add_env_layer_tags(cluster, tenant, layer, entity, tag_list):
-    """Add tags to entity Layer
-
-    Args:
-        cluster (cluster dict): Currently selected cluster
-        tenant (str): Tenant to operate in
-        layer (str): Topology Layer to pull from
-        entity (str): Entity to add tags to
-        tag_list (list): All tags to add to entity
-
-    Raises:
-        TypeError: [description]
-
-    Returns:
-        [type]: [description]
+def add_tags(cluster, tenant, tag_list, entity_type=None, entity_id=None, params=None):
     """
-    layer_list = ['applications', 'hosts',
-                  'custom', 'process-groups', 'services']
-    check_valid_layer(layer, layer_list)
+    Add tags to entities. Must specify tag key. Must specify at least
+    an Entity Type or ID.\n
+
+    @param cluster - Dynatrace Cluster\n
+    @param tenant - Dynatrace Tenant\n
+    @param tag_list - list of tags as dictionaries with "key" and
+                      optionally "value" attributes\n
+    @param entity_type - use EntityTypes enum for this\n
+    @param entity_id - ID of entity. You can specify several IDs, quoted and
+                       separated by a comma ("id-1","id-2").\n
+    @param params - other query string parameters compatible with this API.\n\n
+    @throws TypeError - if tag_list is empty or not a list\n
+    @throws ValueError - if neither entity_type nor entity_id are specified
+    """
+    # Sanity checking, error handling
     if not tag_list:
-        raise TypeError("tag_list cannot be None type")
-    tag_json = {
-        'tags': tag_list
-    }
-    return set_env_layer_properties(cluster, tenant, layer, entity, tag_json)
+        raise TypeError("No tags provided")
+    elif not isinstance(tag_list, list):
+        raise TypeError("tags_list is not a list")
+    elif not any([entity_type, entity_id]):
+        raise ValueError("Must specifiy at least either entity_type or entity_id")
+
+    # Params may already contain an entitySelector, we mustn't overwrite
+    if entity_type:
+        if params['entitySelector']:
+            params['entitySelector'] += f'type("{entity_type}")'
+        else:
+            params['entitySelector'] = f'type("{entity_type}")'
+    if entity_id:
+        if params['entitySelector']:
+            params['entitySelector'] += f'entityId({entity_id})'
+        else:
+            params['entitySelector'] = f'type({entity_id})'
+
+    response = rh.make_api_call(
+        cluster=cluster,
+        tenant=tenant,
+        method=rh.HTTP.POST,
+        endpoint=rh.TenantAPIs.TAGS,
+        params=params
+    )
+
+    return response
+
+
+def delete_tag(cluster, tenant, tag_key, entity_type=None, entity_id=None,
+               tag_value=None, params=None):
+    """
+    Delete tag from entities. Must specify at least an Entity Type or ID.\n
+
+    @param cluster - Dynatrace Cluster\n
+    @param tenant - Dynatrace Tenant\n
+    @param tag_key - the key of the tag(s) to be deleted\n
+    @param tag_value - the values for the tag key to be deleted.
+                       Use "all" to delete all values for the key.\n
+    @param entity_type - use EntityTypes enum for this\n
+    @param entity_id - ID of entity. You can specify several IDs, quoted and
+                       separated by a comma ("id-1","id-2").\n
+    @param params - other query string parameters compatible with this API.\n\n
+    @throws TypeError - if tag_key is empty or missing\n
+    @throws ValueError - if neither entity_type nor entity_id are specified
+    """
+    # Sanity checking, error handling
+    if not tag_key:
+        raise TypeError("No tag key provided")
+    elif not any([entity_type, entity_id]):
+        raise ValueError("Must specifiy at least either entity_type or entity_id")
+
+    # Params may already contain an entitySelector, we mustn't overwrite
+    if entity_type:
+        if params.get('entitySelector'):
+            params['entitySelector'] += f'type("{entity_type}")'
+        else:
+            params['entitySelector'] = f'type("{entity_type}")'
+    if entity_id:
+        if params.get('entitySelector'):
+            params['entitySelector'] += f'entityId({entity_id})'
+        else:
+            params['entitySelector'] = f'type({entity_id})'
+
+    # Set params for tag key & value
+    params['key'] = tag_key
+    if tag_value == "all":
+        params['deleteAllWithKey'] = True
+    elif tag_value:
+        params['value'] = tag_value
+
+    response = rh.make_api_call(
+        cluster=cluster,
+        tenant=tenant,
+        method=rh.HTTP.DELETE,
+        endpoint=rh.TenantAPIs.TAGS,
+        params=params
+    )
+    return response

--- a/dynatrace/tenant/topology/shared.py
+++ b/dynatrace/tenant/topology/shared.py
@@ -1,3 +1,5 @@
+"""Module for core entity operations"""
+
 from enum import Enum, auto
 from dynatrace.requests import request_handler as rh
 
@@ -151,8 +153,8 @@ def get_entity(cluster, tenant, entity_id, params=None):
 
     if len(response.json().get('entities')) == 1:
         return response.json().get('entities')[0]
-    else:
-        return response.json().get('entities')
+
+    return response.json().get('entities')
 
 
 def get_env_entity_count(cluster, tenant, entity_type, params=None):
@@ -236,9 +238,9 @@ def add_tags(cluster, tenant, tag_list, entity_type=None, entity_id=None, params
     # Sanity checking, error handling
     if not tag_list:
         raise TypeError("No tags provided")
-    elif not isinstance(tag_list, list):
+    if not isinstance(tag_list, list):
         raise TypeError("tags_list is not a list")
-    elif not any([entity_type, entity_id]):
+    if not any([entity_type, entity_id]):
         raise ValueError("Must specifiy at least either entity_type or entity_id")
 
     # Params may already contain an entitySelector, we mustn't overwrite
@@ -288,7 +290,7 @@ def delete_tag(cluster, tenant, tag_key, entity_type=None, entity_id=None,
     # Sanity checking, error handling
     if not tag_key:
         raise TypeError("No tag key provided")
-    elif not any([entity_type, entity_id]):
+    if not any([entity_type, entity_id]):
         raise ValueError("Must specifiy at least either entity_type or entity_id")
 
     # Params may already contain an entitySelector, we mustn't overwrite

--- a/tests/mockserver_payloads/responses/host_groups/mock_get_general_1.json
+++ b/tests/mockserver_payloads/responses/host_groups/mock_get_general_1.json
@@ -1,34 +1,14 @@
-[{
-    "entityId": "HOST-238441A17F95B305",
-    "displayName": "testserver",
-    "discoveredName": "testserver",
-    "firstSeenTimestamp": 1592513300463,
-    "lastSeenTimestamp": 1592980597441,
-    "tags": [],
-    "fromRelationships": {},
-    "toRelationships": {
-        "isProcessOf": [],
-        "runsOn": []
-    },
-    "osType": "LINUX",
-    "osArchitecture": "X86",
-    "osVersion": "Debian GNU/Linux 10 (buster) (kernel 4.19.0-9-amd64)",
-    "bitness": "64bit",
-    "cpuCores": 1,
-    "logicalCpuCores": 2,
-    "monitoringMode": "FULL_STACK",
-    "networkZoneId": "default",
-    "agentVersion": {
-        "major": 1,
-        "minor": 195,
-        "revision": 54,
-        "timestamp": "20200529-113801",
-        "sourceRevision": ""
-    },
-    "consumedHostUnits": 8.0,
-    "userLevel": "SUPERUSER",
-    "hostGroup": {
-        "meId": "HOST_GROUP-ABCDEFGH12345678",
-        "name": "HOST_GROUP_1"
-    }
-}]
+{
+    "totalCount": 2,
+    "pageSize": 50,
+    "entities": [
+        {
+            "entityId": "HOST_GROUP-ABC123DEF456GHI7",
+            "displayName": "TEST_HOSTGROUP_1"
+        },
+        {
+            "entityId": "HOST_GROUP-DEF345GHI678JKL9",
+            "displayName": "TEST_HOSTGROUP_2"
+        }
+    ]
+}

--- a/tests/mockserver_payloads/responses/hosts/get_single.json
+++ b/tests/mockserver_payloads/responses/hosts/get_single.json
@@ -1,4 +1,10 @@
 {
-  "entityId": "HOST-ABC123DEF456GHIJ",
-  "consumedHostUnits": 0.25
+    "totalCount": 1,
+    "pageSize": 50,
+    "entities": [
+        {
+            "entityId": "HOST-ABC123DEF456GHIJ",
+            "consumedHostUnits": 0.25
+        }
+    ]
 }

--- a/tests/mockserver_payloads/responses/hosts/v1_get_all.json
+++ b/tests/mockserver_payloads/responses/hosts/v1_get_all.json
@@ -1,7 +1,4 @@
-{
-    "totalCount": 3,
-    "pageSize": 50,
-    "entities": [
+[
         {
             "entityId": "HOST-ABC123DEF456GHIJ",
             "consumedHostUnits": 0.25
@@ -14,5 +11,4 @@
             "entityId": "HOST-421D60DB4A2EA929",
             "consumedHostUnits": 3.5
         }
-    ]
-}
+]

--- a/tests/mockserver_payloads/responses/processes/get_all_pgis.json
+++ b/tests/mockserver_payloads/responses/processes/get_all_pgis.json
@@ -1,11 +1,16 @@
-[
-  {
-    "entityId": "PROCESS_GROUP_INSTANCE-ABC123DEF456GHI7"
-  },
-  {
-    "entityId": "PROCESS_GROUP_INSTANCE-A6AAFEA17E6F60FD"
-  },
-  {
-    "entityId": "PROCESS_GROUP_INSTANCE-F0967E6BFEE20424"
-  }
-]
+{
+    "totalCount": 3,
+    "pageSize": 50,
+    "entities":
+        [
+            {
+                "entityId": "PROCESS_GROUP_INSTANCE-ABC123DEF456GHI7"
+            },
+            {
+                "entityId": "PROCESS_GROUP_INSTANCE-A6AAFEA17E6F60FD"
+            },
+            {
+                "entityId": "PROCESS_GROUP_INSTANCE-F0967E6BFEE20424"
+            }
+        ]
+}

--- a/tests/mockserver_payloads/responses/processes/get_all_pgs.json
+++ b/tests/mockserver_payloads/responses/processes/get_all_pgs.json
@@ -1,11 +1,15 @@
-[
-    {
-        "entityId": "PROCESS_GROUP-ABC123DEF456GHI7"
-    },
-    {
-        "entityId": "PROCESS_GROUP-19DACA5E22637C33"
-    },
-    {
-        "entityId": "PROCESS_GROUP-859E1549052CD876"
-    }
-]
+{
+    "totalCount": 3,
+    "pageSize": 50,
+    "entities": [
+        {
+            "entityId": "PROCESS_GROUP-ABC123DEF456GHI7"
+        },
+        {
+            "entityId": "PROCESS_GROUP-19DACA5E22637C33"
+        },
+        {
+            "entityId": "PROCESS_GROUP-859E1549052CD876"
+        }
+    ]
+}

--- a/tests/mockserver_payloads/responses/processes/get_one_pg.json
+++ b/tests/mockserver_payloads/responses/processes/get_one_pg.json
@@ -1,5 +1,5 @@
 {
-    "totalCount": 3,
+    "totalCount": 1,
     "pageSize": 50,
     "entities": [
         {

--- a/tests/mockserver_payloads/responses/processes/get_one_pg.json
+++ b/tests/mockserver_payloads/responses/processes/get_one_pg.json
@@ -1,3 +1,9 @@
 {
-    "entityId": "PROCESS_GROUP-ABC123DEF456GHI7"
+    "totalCount": 3,
+    "pageSize": 50,
+    "entities": [
+        {
+            "entityId": "PROCESS_GROUP-ABC123DEF456GHI7"
+        }
+    ]
 }

--- a/tests/mockserver_payloads/responses/processes/get_one_pgi.json
+++ b/tests/mockserver_payloads/responses/processes/get_one_pgi.json
@@ -1,5 +1,5 @@
 {
-    "totalCount": 3,
+    "totalCount": 1,
     "pageSize": 50,
     "entities": [
         {

--- a/tests/mockserver_payloads/responses/processes/get_one_pgi.json
+++ b/tests/mockserver_payloads/responses/processes/get_one_pgi.json
@@ -1,3 +1,9 @@
 {
-  "entityId": "PROCESS_GROUP_INSTANCE-ABC123DEF456GHI7"
+    "totalCount": 3,
+    "pageSize": 50,
+    "entities": [
+        {
+            "entityId": "PROCESS_GROUP_INSTANCE-ABC123DEF456GHI7"
+        }
+    ]
 }

--- a/tests/mockserver_payloads/responses/services/get_all.json
+++ b/tests/mockserver_payloads/responses/services/get_all.json
@@ -1,11 +1,15 @@
-[
-    {
-        "entityId": "SERVICE-ABC123DEF456GHI7"
-    },
-    {
-        "entityId": "SERVICE-C096CE0BA471AEFD"
-    },
-    {
-        "entityId": "SERVICE-B71ADA892013D156"
-    }
-]
+{
+    "totalCount": 3,
+    "pageSize": 50,
+    "entities": [
+        {
+            "entityId": "SERVICE-ABC123DEF456GHI7"
+        },
+        {
+            "entityId": "SERVICE-C096CE0BA471AEFD"
+        },
+        {
+            "entityId": "SERVICE-B71ADA892013D156"
+        }
+    ]
+}

--- a/tests/mockserver_payloads/responses/services/get_one.json
+++ b/tests/mockserver_payloads/responses/services/get_one.json
@@ -1,3 +1,9 @@
 {
-    "entityId": "SERVICE-ABC123DEF456GHI7"
+    "totalCount": 1,
+    "pageSize": 50,
+    "entities": [
+        {
+            "entityId": "SERVICE-ABC123DEF456GHI7"
+        }
+    ]
 }

--- a/tests/test_host_groups.py
+++ b/tests/test_host_groups.py
@@ -16,8 +16,8 @@ class TestHostGroupFunctions(unittest.TestCase):
     def test_get_host_groups_tenantwide(self):
         """Testing Retreival of all Host Groups within a single tenant"""
         parameters = {
-            "relativeTime": ["day"],
-            "includeDetails": ["true"],
+            "relativeTime": "day",
+            "includeDetails": "true",
         }
         mockserver_response_file = f"{self.RESPONSE_DIR}mock_get_general_1.json"
         tooling_for_test.create_mockserver_expectation(

--- a/tests/test_topology_hosts.py
+++ b/tests/test_topology_hosts.py
@@ -2,7 +2,7 @@
 Test Suite for Topology Hosts
 """
 import unittest
-from variable_sets.radu_vars import FULL_SET  # pylint: disable=import-error
+from user_variables import FULL_SET  # pylint: disable=import-error
 from tests import tooling_for_test as testtools
 from dynatrace.requests.request_handler import TenantAPIs
 from dynatrace.tenant.topology import hosts

--- a/tests/test_topology_hosts.py
+++ b/tests/test_topology_hosts.py
@@ -2,14 +2,16 @@
 Test Suite for Topology Hosts
 """
 import unittest
-from user_variables import FULL_SET  # pylint: disable=import-error
+from variable_sets.radu_vars import FULL_SET  # pylint: disable=import-error
 from tests import tooling_for_test as testtools
 from dynatrace.requests.request_handler import TenantAPIs
 from dynatrace.tenant.topology import hosts
 
 CLUSTER = FULL_SET["mockserver1"]
 TENANT = "tenant1"
-URL_PATH = f"{TenantAPIs.V1_TOPOLOGY}/infrastructure/hosts"
+URL_PATH = str(TenantAPIs.ENTITIES)
+V1_URL_PATH = f'{TenantAPIs.V1_TOPOLOGY}/infrastructure/hosts'
+TAG_URL_PATH = str(TenantAPIs.TAGS)
 REQUEST_DIR = "tests/mockserver_payloads/requests/hosts"
 RESPONSE_DIR = "tests/mockserver_payloads/responses/hosts"
 
@@ -27,28 +29,36 @@ class TestGetHosts(unittest.TestCase):
             tenant=TENANT,
             url_path=URL_PATH,
             request_type="GET",
+            parameters={
+                'entitySelector': 'type("HOST")'
+            },
             response_file=response_file
         )
 
         result = hosts.get_hosts_tenantwide(CLUSTER, TENANT)
-        self.assertEqual(result, testtools.expected_payload(response_file))
+        expected_result = testtools.expected_payload(response_file).get('entities')
+        self.assertEqual(result, expected_result)
 
     def test_get_single_host(self):
         """Test fetching a specific host"""
 
-        host_id = "HOST-9F74450267BAAE20"
+        host_id = "HOST-ABC123DEF456GHIJ"
         response_file = f"{RESPONSE_DIR}/get_single.json"
 
         testtools.create_mockserver_expectation(
             cluster=CLUSTER,
             tenant=TENANT,
-            url_path=f"{URL_PATH}/{host_id}",
+            url_path=URL_PATH,
             request_type="GET",
+            parameters={
+                'entitySelector': f'entityId({host_id})'
+            },
             response_file=response_file
         )
 
         result = hosts.get_host(CLUSTER, TENANT, host_id)
-        self.assertEqual(result, testtools.expected_payload(response_file))
+        expected_result = testtools.expected_payload(response_file).get('entities')[0]
+        self.assertEqual(result, expected_result)
 
     def test_get_host_count(self):
         """Test getting the count of hosts in a tenant."""
@@ -60,8 +70,10 @@ class TestGetHosts(unittest.TestCase):
             url_path=URL_PATH,
             request_type="GET",
             response_file=response_file,
-            parameters=dict(relativeTime=['day'],
-                            includeDetails=['False'])
+            parameters={
+                'from': 'now-24h',
+                'entitySelector': 'type("HOST")'
+            }
         )
 
         result = hosts.get_host_count_tenantwide(CLUSTER, TENANT)
@@ -70,11 +82,11 @@ class TestGetHosts(unittest.TestCase):
     def test_get_host_units(self):
         """Tests getting the consumed host units in a tenant."""
 
-        response_file = f"{RESPONSE_DIR}/get_all.json"
+        response_file = f"{RESPONSE_DIR}/v1_get_all.json"
         testtools.create_mockserver_expectation(
             cluster=CLUSTER,
             tenant=TENANT,
-            url_path=URL_PATH,
+            url_path=V1_URL_PATH,
             request_type="GET",
             response_file=response_file
         )
@@ -97,13 +109,16 @@ class TestHostTagging(unittest.TestCase):
             cluster=CLUSTER,
             tenant=TENANT,
             request_type="POST",
-            url_path=f"{URL_PATH}/{host_id}",
+            url_path=TAG_URL_PATH,
             request_file=request_file,
+            parameters={
+                'entitySelector': f'entityId({host_id})'
+            },
             response_code=201
         )
 
         result = hosts.add_host_tags(CLUSTER, TENANT, host_id, tags)
-        self.assertEqual(result, 201)
+        self.assertEqual(result.status_code, 201)
 
     def test_delete_tags(self):
         """Test deleting a tag from a specific host."""
@@ -114,7 +129,7 @@ class TestHostTagging(unittest.TestCase):
         testtools.create_mockserver_expectation(
             cluster=CLUSTER,
             tenant=TENANT,
-            url_path=f"{URL_PATH}/{host_id}/tags/{tag}",
+            url_path=TAG_URL_PATH,
             request_type="DELETE",
             response_code=204
         )

--- a/tests/test_topology_process_groups.py
+++ b/tests/test_topology_process_groups.py
@@ -3,12 +3,15 @@
 import unittest
 from user_variables import FULL_SET  # pylint: disable=import-error
 from tests import tooling_for_test as testtools
+from dynatrace.tenant.topology.shared import EntityTypes
 from dynatrace.requests.request_handler import TenantAPIs
 from dynatrace.tenant.topology import process_groups
 
 CLUSTER = FULL_SET.get('mockserver1')
 TENANT = 'tenant1'
-URL_PATH = f"{TenantAPIs.V1_TOPOLOGY}/infrastructure/process-groups"
+URL_PATH = f"{TenantAPIs.ENTITIES}"
+TAG_URL_PATH = f"{TenantAPIs.TAGS}"
+ENTITY = f"{EntityTypes.PROCESS_GROUP}"
 REQUEST_DIR = "tests/mockserver_payloads/requests/processes"
 RESPONSE_DIR = "tests/mockserver_payloads/responses/processes"
 
@@ -25,11 +28,15 @@ class TestGetPGs(unittest.TestCase):
             tenant=TENANT,
             url_path=URL_PATH,
             request_type="GET",
+            parameters={
+                'entitySelector': f'type("{ENTITY}")'
+            },
             response_file=response_file
         )
 
         result = process_groups.get_process_groups_tenantwide(CLUSTER, TENANT)
-        self.assertEqual(result, testtools.expected_payload(response_file))
+        expected_result = testtools.expected_payload(response_file).get('entities')
+        self.assertEqual(result, expected_result)
 
     def test_get_single_pg(self):
         """Test fetching single PG"""
@@ -39,13 +46,17 @@ class TestGetPGs(unittest.TestCase):
         testtools.create_mockserver_expectation(
             cluster=CLUSTER,
             tenant=TENANT,
-            url_path=f"{URL_PATH}/{pg_id}",
+            url_path=URL_PATH,
             request_type="GET",
+            parameters={
+                'entitySelector': f'entityId({pg_id})'
+            },
             response_file=response_file
         )
 
         result = process_groups.get_process_group(CLUSTER, TENANT, pg_id)
-        self.assertEqual(result, testtools.expected_payload(response_file))
+        expected_result = testtools.expected_payload(response_file).get('entities')[0]
+        self.assertEqual(result, expected_result)
 
     def test_get_pg_count(self):
         """Test getting the PG count tenantwide."""
@@ -56,11 +67,13 @@ class TestGetPGs(unittest.TestCase):
             tenant=TENANT,
             url_path=URL_PATH,
             request_type="GET",
+            parameters={
+                'entitySelector': f'type("{ENTITY}")'
+            },
             response_file=response_file
         )
 
-        result = process_groups.get_process_group_count_tenantwide(CLUSTER,
-                                                                   TENANT)
+        result = process_groups.get_process_group_count_tenantwide(CLUSTER, TENANT)
         self.assertEqual(result, 3)
 
 
@@ -77,14 +90,17 @@ class TestPGTags(unittest.TestCase):
             cluster=CLUSTER,
             tenant=TENANT,
             request_type="POST",
-            url_path=f"{URL_PATH}/{pg_id}",
+            url_path=TAG_URL_PATH,
             request_file=request_file,
+            parameters={
+                'entitySelector': f'entityId({pg_id})'
+            },
             response_code=201
         )
 
         result = process_groups.add_process_group_tags(CLUSTER, TENANT,
                                                        pg_id, tags)
-        self.assertEqual(result, 201)
+        self.assertEqual(result.status_code, 201)
 
 
 if __name__ == '__main__':

--- a/tests/test_topology_processes.py
+++ b/tests/test_topology_processes.py
@@ -4,12 +4,14 @@ import unittest
 from tests import tooling_for_test as testtools
 from dynatrace import settings
 from dynatrace.requests.request_handler import TenantAPIs
+from dynatrace.tenant.topology.shared import EntityTypes
 from dynatrace.tenant.topology import process
 
 FULL_SET = settings.get_setting("FULL_SET")
 CLUSTER = FULL_SET.get('mockserver1')
 TENANT = 'tenant1'
-URL_PATH = f"{TenantAPIs.V1_TOPOLOGY}/infrastructure/processes"
+URL_PATH = f"{TenantAPIs.ENTITIES}"
+TYPE = f"{EntityTypes.PROCESS_GROUP_INSTANCE}"
 RESPONSE_DIR = "tests/mockserver_payloads/responses/processes"
 
 
@@ -25,11 +27,15 @@ class TestGetProcesses(unittest.TestCase):
             tenant=TENANT,
             url_path=URL_PATH,
             request_type="GET",
+            parameters={
+                'entitySelector': f'type("{TYPE}")'
+            },
             response_file=response_file
         )
 
         result = process.get_processes_tenantwide(CLUSTER, TENANT)
-        self.assertEqual(result, testtools.expected_payload(response_file))
+        expected_result = testtools.expected_payload(response_file).get('entities')
+        self.assertEqual(result, expected_result)
 
     def test_get_single_process(self):
         """Tests getting one specific process."""
@@ -39,13 +45,17 @@ class TestGetProcesses(unittest.TestCase):
         testtools.create_mockserver_expectation(
             cluster=CLUSTER,
             tenant=TENANT,
-            url_path=f"{URL_PATH}/{process_id}",
+            url_path=URL_PATH,
             request_type="GET",
+            parameters={
+                'entitySelector': f'entityId({process_id})'
+            },
             response_file=response_file
         )
 
         result = process.get_process(CLUSTER, TENANT, process_id)
-        self.assertEqual(result, testtools.expected_payload(response_file))
+        expected_result = testtools.expected_payload(response_file).get('entities')[0]
+        self.assertEqual(result, expected_result)
 
 
 if __name__ == '__main__':

--- a/tests/tooling_for_test.py
+++ b/tests/tooling_for_test.py
@@ -40,9 +40,16 @@ def create_mockserver_expectation(cluster, tenant, url_path, request_type, **kwa
 
     logging.debug("URL PATH: %s", url_path)
     logging.debug("KWARGS %s", kwargs)
-    # Paramaters should always at least have Api-Token
+
+    # Mockserver expectation syntax expects each parameter's matching values
+    # to be given as a list (even if just 1 value)
     if 'parameters' in kwargs:
-        expectation["httpRequest"]["queryStringParameters"] = kwargs['parameters']
+        expectation["httpRequest"]["queryStringParameters"] = {
+            param: [
+                kwargs['parameters'][param]
+            ]
+            for param in kwargs['parameters']
+        }
 
     if "request_file" in kwargs:
         with open(kwargs['request_file']) as open_file:


### PR DESCRIPTION
topology > shared - all functions now use V2 instead of V1
topology > applications, custom, hosts, process_groups, process, services - all functions updated to call the new shared.py functionality (function headers stayed the same to ensure previous scripts can still use them)
tenant > host_groups - updated to call the new shared.py functionality

tests > test_host_groups, test_topology_hosts, test_topology_process_groups, test_topology_processes, test_topology_services all updated to work with the new functionality

tooling_for_test > modified parameters to comply with mockserver expectation schema while allowing us to pass them normally upstream (when creating the expectation in the test case)